### PR TITLE
:bug: Load firebase auth before application

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4,11 +4,23 @@ import './plugins/vuetify'
 import App from './App.vue'
 import router from './router'
 import store from './store'
+import { auth } from './utils/firebaseConfig';
 
 Vue.config.productionTip = false
 
-new Vue({
-  router,
-  store,
-  render: h => h(App)
-}).$mount('#app')
+let app = null
+
+// Wait for firebase auth to init before creating the app
+auth.onAuthStateChanged(() => {
+  
+  // init app if not already created
+  if (!app) {
+    app = new Vue({
+      router,
+      store,
+      render: h => h(App)
+    }).$mount('#app')
+  }
+
+})
+


### PR DESCRIPTION
This resolves an L3 bug with the auth where occasionally the vue app would load and a user would try to log in before firebase auth was available.

cc/ @ryanboris for 👀 

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced at the bottom of the PR's body or in a commit message(e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] Code has been reviewed by at least one team member
- [x] There are no new errors in the console
- [x] Vue's linter shows no code reccomendations
