### PR TITLE
Fix/router auth

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -1,6 +1,6 @@
 import Vue from "vue";
 import Router from "vue-router";
-import axios from 'axios';
+import axios from "axios";
 import Home from "./views/Home.vue";
 import About from "./views/About.vue";
 import Dashboard from "./views/Dashboard.vue";
@@ -31,21 +31,26 @@ export default new Router({
 });
 
 function requireAuth(to, from, next) {
-  const idToken = localStorage.getItem('idToken')
-
-  axios.get(
-    'https://us-central1-not-wrong-doorman.cloudfunctions.net/server/api/auth',{
-      headers: {
-        authorization: idToken
+  const idToken = localStorage.getItem("idToken");
+  if (!idToken) next({ name: "home", replace: true });
+  axios
+    .get(
+      "https://us-central1-not-wrong-doorman.cloudfunctions.net/server/api/auth",
+      {
+        headers: {
+          authorization: idToken
+        }
       }
-    }).then(res => {
+    )
+    .then(res => {
+      console.log(res);
       if (res.status === 200) {
-        next()
-        return 
-      } 
+        next();
+        return;
+      }
       next({
         name: "home",
         replace: true
-      })
-    })
+      });
+    });
 }

--- a/src/router.js
+++ b/src/router.js
@@ -26,6 +26,10 @@ export default new Router({
       name: "dashboard",
       component: Dashboard,
       beforeEnter: requireAuth
+    },
+    {
+      path: "*",
+      redirect: "/dashboard"
     }
   ]
 });

--- a/src/router.js
+++ b/src/router.js
@@ -47,7 +47,6 @@ function requireAuth(to, from, next) {
       }
     )
     .then(res => {
-      console.log(res);
       if (res.status === 200) {
         next();
         return;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

Does not fully fix auth issue, but adds a couple safeguards to eliminate other potential issues. If safeguard function attempts to fire with no idToken in local storage, immediately redirects the user to home route without make request to the API first since the errors weren't being caught, but also more performant to make that catch prior. Also adds catch-all route that will redirect user to dashboard route if any invalid route is accessed. Original issue still persists where when accessing the protected route with a token in storage, but while logged out, 200 status is returned and user therefore has access to the dashboard--but without the github login, their data will not be set in state

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced at the bottom of the PR's body or in a commit message(e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] Code has been reviewed by at least one team member
- [x] There are no new errors in the console
- [x] Vue's linter shows no code reccomendations
