### PR TITLE
:bug: Empty filter list no longer breaks list

### DIFF
--- a/src/components/DashBoard/PopUp.vue
+++ b/src/components/DashBoard/PopUp.vue
@@ -9,12 +9,10 @@
         </h2>
       </v-card-title>
       <v-card-text class="title">
-        This Github user is currently
-        <span
-          v-if="!blocked"
-        >whitelisted and any requests from them will be automatically accepted.</span>
-        <span v-else>blacklisted and any requests from them will be automatically refused.</span>
-        Change this rule?
+        Any requests from this Github user will currently be
+        <span v-if="!blocked">accepted</span>
+        <span v-else>refused</span>
+        automatically. Change this rule?
       </v-card-text>
       <v-spacer></v-spacer>
       <v-card-actions>
@@ -24,19 +22,19 @@
             flat
             class="success flex-btn px-4"
             @click="addBlocked(selectedUser), dialog=false"
-          >Yes, block this user</v-btn>
+          >Yes, block requests</v-btn>
           <v-btn
             v-else
             flat
             class="success flex-btn px-4"
             @click="addAllowed(selectedUser), dialog=false"
-          >Yes, whitelist this user</v-btn>
+          >Yes, accept requests</v-btn>
           <v-btn
             flat
             class="primary flex-btn px-4"
             width="100%"
             @click="deleteUser(selectedUser), dialog=false"
-          >Delete all rules for user</v-btn>
+          >Remove user from list</v-btn>
           <v-btn flat class="error flex-btn px-4" @click="dialog=false">Cancel</v-btn>
         </div>
       </v-card-actions>
@@ -71,7 +69,7 @@ export default {
 .button-group {
   display: flex;
   width: 100%;
-  justify-content: space-between;
+  justify-content: space-evenly;
 }
 @media (max-width: 600px) {
   .button-group {

--- a/src/components/DashBoard/UserList.vue
+++ b/src/components/DashBoard/UserList.vue
@@ -1,39 +1,48 @@
 <template>
   <v-app class="users-list" dark>
     <v-container class="my-5">
-      <v-btn-toggle v-if="currentUser && returnFilter.length>0" v-model="filter">
+      <v-btn-toggle v-if="currentUser && blockedAndAllowedList.length>0" v-model="filter">
         <v-btn flat value="all" class="primary secondary--text">All</v-btn>
         <v-btn flat value="allow" class="primary secondary--text">Accepted</v-btn>
         <v-btn flat value="block" class="primary secondary--text">Declined</v-btn>
       </v-btn-toggle>
-      <v-card class="pa-3 my-3 secondary userlist" v-for="(user, i) in returnFilter" :key="i">
-        <v-layout row justify-space-between>
-          <v-flex xs3>
-            <v-card
-              :href="user.html_url"
-              target="_blank"
-              class="py-1 text-xs-left username primary--text"
-              width="200"
-            >
-              <v-avatar class="mr-4 ml-2">
-                <img :src="user.avatar_url" />
-              </v-avatar>
-              {{user.login}}
-            </v-card>
-          </v-flex>
-          <v-flex xs6 class="mr-2 text-xs-right">
-            <v-icon
-              large
-              v-if="Boolean(currentUser.allow[`${user.id}`])"
-              right
-              class="success--text"
-            >check</v-icon>
-            <v-icon large v-else right class="error--text">block</v-icon>
-            <PopUp :selected-user="user" :blocked="Boolean(currentUser.block[`${user.id}`])">
-              <v-btn class="primary secondary--text">Edit</v-btn>
-            </PopUp>
-          </v-flex>
-        </v-layout>
+      <div v-if="returnFilter.length>0">
+        <v-card class="pa-3 my-3 secondary userlist" v-for="(user, i) in returnFilter" :key="i">
+          <v-layout row justify-space-between>
+            <v-flex xs3>
+              <v-card
+                :href="user.html_url"
+                target="_blank"
+                class="py-1 text-xs-left username primary--text"
+                width="200"
+              >
+                <v-avatar class="mr-4 ml-2">
+                  <img :src="user.avatar_url" />
+                </v-avatar>
+                {{user.login}}
+              </v-card>
+            </v-flex>
+            <v-flex xs6 class="mr-2 text-xs-right">
+              <v-icon
+                large
+                v-if="Boolean(currentUser.allow[`${user.id}`])"
+                right
+                class="success--text"
+              >check</v-icon>
+              <v-icon large v-else right class="error--text">block</v-icon>
+              <PopUp :selected-user="user" :blocked="Boolean(currentUser.block[`${user.id}`])">
+                <v-btn class="primary secondary--text">Edit</v-btn>
+              </PopUp>
+            </v-flex>
+          </v-layout>
+        </v-card>
+      </div>
+      <v-card v-else class="pa-3 mt-3">
+        <v-card>
+          <v-card-text
+            class="subheading font-weight-medium text-xs-center"
+          >You currently don't have any users in this list. Check the other filters to see who you currently have rules for.</v-card-text>
+        </v-card>
       </v-card>
     </v-container>
   </v-app>


### PR DESCRIPTION
Userlist was formerly checking if the currently filtered list had users in it to display the whole list component, including the fitler buttons. Caused issue where buttons and list would disappear entirely when a filter was applied that returned no users. Now the list displays so long as any users are blocked OR allowed, and if the current filtered list is empty it displays a message to that effect and prompts the user to check out the other filter options

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced at the bottom of the PR's body or in a commit message(e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] Code has been reviewed by at least one team member
- [x] There are no new errors in the console
- [x] Vue's linter shows no code reccomendations
